### PR TITLE
Plagiarism finder excerpt builder fix not finding end word bug

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,8 +120,6 @@ lazy val restApi = (project in file("restApi"))
     commonSettings,
     name := "WikiPlagRestAPI",
     libraryDependencies ++= testDependencies,
-    //TODO @Anton remove spark and cass dependencies if not used by Max
-    //libraryDependencies ++=sparkDependencies,
     libraryDependencies ++= sparkDependencies_compile,
     libraryDependencies ++= cassandraDependencies,
     libraryDependencies ++= Seq(
@@ -134,8 +132,7 @@ lazy val restApi = (project in file("restApi"))
       "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided",
       "org.scalatra" %% "scalatra-json" % ScalatraVersion,
       //library used for json conversion
-      "org.json4s" %% "json4s-jackson" % "3.5.2",
-      "com.sun.jersey" % "jersey-server" % "1.2",
+      "org.json4s" %% "json4s-jackson" % "3.5.2"
       //add further required dependencies here
 
     ),

--- a/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
+++ b/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
@@ -13,7 +13,7 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     * @param plagiarismCandidates the result of the [[PlagiarismFinder.findPlagiarisms()]] Method
     * @param n                    number of words to include before and after plagiarism
     * */
-  private def buildWikiExcerpts(plagiarismCandidates: Map[TextPosition, List[(Vector[String], Int)]], n: Int): List[WikiPlagiarism] = {
+  def buildWikiExcerpts(plagiarismCandidates: Map[TextPosition, List[(Vector[String], Int)]], n: Int): List[WikiPlagiarism] = {
 
     var docIds = plagiarismCandidates.values.flatten.map(_._2)
     var documentsMap = cassandraClient.queryArticlesAsMap(docIds)
@@ -47,10 +47,9 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     * @return a tuple of (n-words before, plagiarism, n-words after)
     * */
   //TODO. n can be the just whitespaced tokens before and after or even just characters
-  def findExactWikipediaExcerpt(tokenizedMatch: Vector[String], wikiText: String, n: Int): Tuple3[String, String, String] = {
-    //produce list from input text string
-    val wikiTextList = wikiText.split(" ")
-    //TODO remove punctuation
+  private def findExactWikipediaExcerpt(tokenizedMatch: Vector[String], wikiText: String, n: Int): Tuple3[String, String, String] = {
+    //produce list from input text string and removes punctuation
+    val wikiTextList = wikiText.split("[ !.?:,]").map(x=>x.replace("[.!?:,]",""))
     val matchstart = tokenizedMatch(0)
     val matchend = tokenizedMatch.last
     val matchdist = tokenizedMatch.size
@@ -67,7 +66,6 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     val wikiTextBefore = wikiTextList.slice(wikiTextPositions._1 - n , wikiTextPositions._1).mkString(" ")
     val wikiTextExcerpt = wikiTextList.slice(wikiTextPositions._1, wikiTextPositions._2).mkString(" ")
     val wikiTextAfter = wikiTextList.slice(wikiTextPositions._2, wikiTextPositions._2 + n).mkString(" ")
-
 
     (wikiTextBefore, wikiTextExcerpt, wikiTextAfter)
   }

--- a/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
+++ b/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
@@ -1,9 +1,8 @@
 package de.htwberlin.f4.wikiplag.plagiarism
 
 import de.htwberlin.f4.wikiplag.plagiarism.models.{TextPosition, WikiExcerpt, WikiPlagiarism}
+import de.htwberlin.f4.wikiplag.utils.Functions
 import de.htwberlin.f4.wikiplag.utils.database.CassandraClient
-
-import scala.collection.immutable.ListMap
 
 /** Builds wikipedia excerpts from the result of the plagiarism finder so they can be served by the rest api. */
 class WikiExcerptBuilder(cassandraClient: CassandraClient) {
@@ -18,56 +17,91 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     var docIds = plagiarismCandidates.values.flatten.map(_._2)
     var documentsMap = cassandraClient.queryArticlesAsMap(docIds)
 
-      plagiarismCandidates.toSeq.sortWith(_._1.start < _._1.start).zipWithIndex.map(x => {
+    plagiarismCandidates.toSeq.sortWith(_._1.start < _._1.start).zipWithIndex.map(x => {
       val startInInputText = x._1._1.start
       val endInInputText = x._1._1.end
-      val excerts=x._1._2.map(x => {
+      val excerts = x._1._2.map(x => {
         val document = documentsMap(x._2)
         val excerptTuple = findExactWikipediaExcerpt(x._1, document.text, n)
         val excerpt = buildDisplayExcrept(excerptTuple._1, excerptTuple._2, excerptTuple._3)
-        new WikiExcerpt(document.title,document.docId, startInInputText, endInInputText, excerpt)
+        new WikiExcerpt(document.title, document.docId, startInInputText, endInInputText, excerpt)
       })
 
-      new WikiPlagiarism(x._2,excerts)
+      new WikiPlagiarism(x._2, excerts)
     }).toList
   }
 
 
   private def buildDisplayExcrept(before: String, plagiarism: String, after: String): String = {
     //specifying the span class in the rest api is absolutely disgusting..
-    var span=""" <span class="wiki_plag">""""
-    s"[...] $before $span$plagiarism $after</span> [...]"
+    var span ="""<span class="wiki_plag">"""
+    s"[...] $before$span$plagiarism</span>$after [...]"
   }
 
   /** Finds the exact excerpt for the tokenized match from the given wikipedia article.
     *
     * @param tokenizedMatch the tokenzied match
     * @param wikiText       the wikipedia article from which the tokenized match originated
-    * @param n              number of words before and after the plagiarism text
+    * @param n              number of characters before and after the plagiarism text
     * @return a tuple of (n-words before, plagiarism, n-words after)
     * */
-  //TODO. n can be the just whitespaced tokens before and after or even just characters
   def findExactWikipediaExcerpt(tokenizedMatch: Vector[String], wikiText: String, n: Int): Tuple3[String, String, String] = {
-    //produce list from input text string
-    val wikiTextList = wikiText.split(" ")
-    //TODO remove punctuation
-    val matchstart = tokenizedMatch(0)
-    val matchend = tokenizedMatch.last
-    val matchdist = tokenizedMatch.size
+    try {
+      findExactWikipediaExcerptOrThrow(tokenizedMatch, wikiText, n)
+    } catch {
+      //if there was an exception write the stack trace and just concatenate the tokens
+      case e: Exception =>
+        e.printStackTrace()
+        ("", tokenizedMatch.mkString(" "), "")
+    }
+  }
 
-    //get positions of first and last element of tokenized match
-    val startpositions = wikiTextList.zipWithIndex.filter(x => x._1 == matchstart).map(_._2)
-    val endpositions = wikiTextList.zipWithIndex.filter(x => x._1 == matchend).map(_._2)
+  private def findExactWikipediaExcerptOrThrow(tokenizedMatch: Vector[String], wikiText: String, n: Int): Tuple3[String, String, String] = {
+    val wikiTextLower = wikiText.toLowerCase
+    //find all positions of each word and remove those with no results
+    val nonEmptyOrderedTokensPositions = tokenizedMatch.map(x => Functions.allIndicesOf(wikiTextLower, x)).filter(_.nonEmpty).toList
 
-    //produce triples (startposition, endposition, distance) of possible candidates
-    //distance must be larger than the size of tokenized match vector to be a possible excerpt
-    val positionpairs = startpositions.flatMap(x => endpositions.filter(_ > x).map(y => (x, y, y-x+1))).filter(_._3 >= matchdist).sortWith(_._3 > _._3)
-    val wikiTextPositions = positionpairs.last
+    //less than two words have been found, throw an exception
+    if (nonEmptyOrderedTokensPositions.size < 2)
+      throw new NoSuchElementException("Less than 2 tokens were found.")
 
-    val wikiTextBefore = wikiTextList.slice(wikiTextPositions._1 - n , wikiTextPositions._1).mkString(" ")
-    val wikiTextExcerpt = wikiTextList.slice(wikiTextPositions._1, wikiTextPositions._2).mkString(" ")
-    val wikiTextAfter = wikiTextList.slice(wikiTextPositions._2, wikiTextPositions._2 + n).mkString(" ")
+    val firstWordPositions = nonEmptyOrderedTokensPositions.head
+    val otherWordsPositions = nonEmptyOrderedTokensPositions.tail
 
-    (wikiTextBefore, wikiTextExcerpt, wikiTextAfter)
+    //build start,end, count of words founds tuples
+    val startEndPositionCountTuples = firstWordPositions.map(startingPosition => {
+      val endPositionWithNumberOfWordsFound = otherWordsPositions.foldLeft(startingPosition, 0) {
+        (accumulator, current) => {
+          val previousPosition = accumulator._2
+          val closestPositionToPrevious = current.find(_ > previousPosition)
+          //no position exists which are after the previous one,
+          // continue with the next query word without modifying the positions
+          if (closestPositionToPrevious.isEmpty)
+            accumulator
+          else
+            (closestPositionToPrevious.get, accumulator._2 + 1)
+        }
+      }
+      (startingPosition, endPositionWithNumberOfWordsFound._1, endPositionWithNumberOfWordsFound._2)
+    })
+
+    //get the one with the most found words
+    val best = startEndPositionCountTuples.maxBy(x => x._3)
+
+    //if it has 0 words throw an exception
+    if (best._3 == 0)
+      throw new NoSuchElementException("0 Element best match.")
+
+    val plagStartPosition = best._1
+    val plagEndPosition = best._2
+    //clip to avoid out of bounds exceptions
+    val beforeStartPosition = math.max(plagStartPosition - n, 0)
+    val afterEndPosition = math.min(plagEndPosition + n, wikiText.length - 1)
+
+    val before = wikiText.slice(beforeStartPosition, plagStartPosition)
+    val plag = wikiText.slice(plagStartPosition, plagEndPosition)
+    val after = wikiText.slice(plagEndPosition, afterEndPosition)
+
+    (before, plag, after)
   }
 }

--- a/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
+++ b/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
@@ -47,9 +47,10 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     * @return a tuple of (n-words before, plagiarism, n-words after)
     * */
   //TODO. n can be the just whitespaced tokens before and after or even just characters
-  private def findExactWikipediaExcerpt(tokenizedMatch: Vector[String], wikiText: String, n: Int): Tuple3[String, String, String] = {
-    //produce list from input text string and removes punctuation
-    val wikiTextList = wikiText.split("[ !.?:,]").map(x=>x.replace("[.!?:,]",""))
+  def findExactWikipediaExcerpt(tokenizedMatch: Vector[String], wikiText: String, n: Int): Tuple3[String, String, String] = {
+    //produce list from input text string
+    val wikiTextList = wikiText.split(" ")
+    //TODO remove punctuation
     val matchstart = tokenizedMatch(0)
     val matchend = tokenizedMatch.last
     val matchdist = tokenizedMatch.size

--- a/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
+++ b/plagiarismFinder/src/main/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilder.scala
@@ -75,7 +75,7 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     val startEndPositionCountTuples = firstWordPositions.map(startingPosition => {
       val endPositionWithNumberOfWordsFound = otherWordsPositions.foldLeft(startingPosition, 0) {
         (accumulator, current) => {
-          val previousPosition = accumulator._2
+          val previousPosition = accumulator._1
           val closestPositionToPrevious = current.find(_ > previousPosition)
           //no position exists which are after the previous one,
           // continue with the next query word without modifying the positions
@@ -100,10 +100,10 @@ class WikiExcerptBuilder(cassandraClient: CassandraClient) {
     //clip to avoid out of bounds exceptions
     val beforeStartPosition = math.max(plagStartPosition - n, 0)
     val afterEndPosition = math.min(plagEndPosition + n, wikiText.length - 1)
-
-    val before = wikiText.slice(beforeStartPosition, plagStartPosition)
-    val plag = wikiText.slice(plagStartPosition, plagEndPosition)
-    val after = wikiText.slice(plagEndPosition, afterEndPosition)
+    
+    val before = wikiText.slice(beforeStartPosition, plagStartPosition).replace("\n","")
+    val plag = wikiText.slice(plagStartPosition, plagEndPosition).replace("\n","")
+    val after = wikiText.slice(plagEndPosition, afterEndPosition).replace("\n","")
 
     (before, plag, after)
   }

--- a/plagiarismFinder/src/test/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilderTest.scala
+++ b/plagiarismFinder/src/test/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilderTest.scala
@@ -31,8 +31,7 @@ class WikiExcerptBuilderTest extends AssertionsForJUnit {
   @Test def testExcerpt(): Unit = {
     val input = raw"Daniel Stenberg, der Programmierer von cURL, begann 1997 ein Programm zu schreiben, das IRC-Teilnehmern Daten über Wechselkurse zur Verfügung stellen sollte, welche von Webseiten abgerufen werden mussten. Er setzte dabei auf das vorhandene Open-Source-Tool httpget. Nach einer Erweiterung um andere Protokolle wurde das Programm am 20. März 1998 als cURL 4 erstmals veröffentlicht. Ursprünglich stand der Name für und wurde erst später vom Stenberg nach einem besseren Vorschlag zum aktuellen Backronym umgedeutet.[2] URL"
     val matches = finder.findPlagiarisms(input, new HyperParameters())
-    //TODO THROWS EXCEPTION
-    val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 3)
+    val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 15)
 
     println(wikiExcerpt.size)
     println(wikiExcerpt)
@@ -49,7 +48,6 @@ class WikiExcerptBuilderTest extends AssertionsForJUnit {
 
     //find plagiarisms using default hyper parameters
     val matches = finder.findPlagiarisms(input + input2, new HyperParameters())
-    //TODO THROWS EXCEPTION
     val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 3)
 
     println(wikiExcerpt.size)
@@ -64,7 +62,6 @@ class WikiExcerptBuilderTest extends AssertionsForJUnit {
   @Test def testExcerpt2(): Unit = {
     val input = raw"Und der wwfawf werwe für einen fiktiven Regisseur der Filme verantwortet, bei denen der eigentliche Regisseur seinen Namen nicht Kontaktenfrom. zuletzt', weil Arthur  Hiller  der eigentliche  regisseur "
     val matches = finder.findPlagiarisms(input, new HyperParameters())
-    //TODO THROWS EXCEPTION
     val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 3)
 
     println(wikiExcerpt.size)

--- a/plagiarismFinder/src/test/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilderTest.scala
+++ b/plagiarismFinder/src/test/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilderTest.scala
@@ -1,0 +1,45 @@
+package de.htwberlin.f4.wikiplag.plagiarism
+
+import de.htwberlin.f4.wikiplag.plagiarism.models.HyperParameters
+import de.htwberlin.f4.wikiplag.utils.CassandraParameters
+import de.htwberlin.f4.wikiplag.utils.database.CassandraClient
+import org.apache.spark.SparkContext
+import org.junit.{After, Before, Test}
+import org.scalatest.junit.AssertionsForJUnit
+
+class WikiExcerptBuilderTest extends AssertionsForJUnit {
+  var n: Int = 4
+  var finder: PlagiarismFinder = _
+  var excerptBuilder: WikiExcerptBuilder=_
+  var sc: SparkContext = _
+
+  @Before def setUp() {
+    var cassandraParameters = CassandraParameters.readFromConfigFile("app.conf")
+
+    val sparkConf = cassandraParameters.toSparkConf("[Wikiplag] Plagiarism finder")
+    sc = new SparkContext(sparkConf)
+    val cassandraClient = new CassandraClient(sc, cassandraParameters)
+    finder = new PlagiarismFinder(cassandraClient)
+    excerptBuilder=new WikiExcerptBuilder(cassandraClient)
+  }
+
+  @After def tearDown() {
+    sc.stop()
+  }
+
+
+  @Test def testExcerpt(): Unit ={
+    val input = raw"Daniel Stenberg, der Programmierer von cURL, begann 1997 ein Programm zu schreiben, das IRC-Teilnehmern Daten über Wechselkurse zur Verfügung stellen sollte, welche von Webseiten abgerufen werden mussten. Er setzte dabei auf das vorhandene Open-Source-Tool httpget. Nach einer Erweiterung um andere Protokolle wurde das Programm am 20. März 1998 als cURL 4 erstmals veröffentlicht. Ursprünglich stand der Name für und wurde erst später vom Stenberg nach einem besseren Vorschlag zum aktuellen Backronym umgedeutet.[2] URL"
+    val matches = finder.findPlagiarisms(input, new HyperParameters())
+    //TODO THROWS EXCEPTION
+    val wikiExcerpt=excerptBuilder.buildWikiExcerpts(matches,3)
+
+    println(wikiExcerpt.size)
+    println(wikiExcerpt)
+    println()
+
+
+    wikiExcerpt.foreach(println(_))
+    assert(true)
+  }
+}

--- a/plagiarismFinder/src/test/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilderTest.scala
+++ b/plagiarismFinder/src/test/scala/de/htwberlin/f4/wikiplag/plagiarism/WikiExcerptBuilderTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.junit.AssertionsForJUnit
 class WikiExcerptBuilderTest extends AssertionsForJUnit {
   var n: Int = 4
   var finder: PlagiarismFinder = _
-  var excerptBuilder: WikiExcerptBuilder=_
+  var excerptBuilder: WikiExcerptBuilder = _
   var sc: SparkContext = _
 
   @Before def setUp() {
@@ -20,7 +20,7 @@ class WikiExcerptBuilderTest extends AssertionsForJUnit {
     sc = new SparkContext(sparkConf)
     val cassandraClient = new CassandraClient(sc, cassandraParameters)
     finder = new PlagiarismFinder(cassandraClient)
-    excerptBuilder=new WikiExcerptBuilder(cassandraClient)
+    excerptBuilder = new WikiExcerptBuilder(cassandraClient)
   }
 
   @After def tearDown() {
@@ -28,11 +28,44 @@ class WikiExcerptBuilderTest extends AssertionsForJUnit {
   }
 
 
-  @Test def testExcerpt(): Unit ={
+  @Test def testExcerpt(): Unit = {
     val input = raw"Daniel Stenberg, der Programmierer von cURL, begann 1997 ein Programm zu schreiben, das IRC-Teilnehmern Daten über Wechselkurse zur Verfügung stellen sollte, welche von Webseiten abgerufen werden mussten. Er setzte dabei auf das vorhandene Open-Source-Tool httpget. Nach einer Erweiterung um andere Protokolle wurde das Programm am 20. März 1998 als cURL 4 erstmals veröffentlicht. Ursprünglich stand der Name für und wurde erst später vom Stenberg nach einem besseren Vorschlag zum aktuellen Backronym umgedeutet.[2] URL"
     val matches = finder.findPlagiarisms(input, new HyperParameters())
     //TODO THROWS EXCEPTION
-    val wikiExcerpt=excerptBuilder.buildWikiExcerpts(matches,3)
+    val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 3)
+
+    println(wikiExcerpt.size)
+    println(wikiExcerpt)
+    println()
+
+
+    wikiExcerpt.foreach(println(_))
+    assert(true)
+  }
+
+  @Test def testExcerpt3(): Unit = {
+    val input = raw"Korpiklaani (finn. „Klan der Wildnis“, auch „Klan des Waldes“) ist eine finnische Folk-Metal-Band aus Lahti mit starken Einflüssen aus der traditionellen Volksmusik. Die Texte der Band handeln von mythologischen Themen sowie der Natur und dem Feiern, wobei auch reine Instrumentalstücke in ihrem Repertoire enthalten sind. Sie selbst sehen ihre Musik auch vom Humppa beeinflusst. Bislang wurden sechs reguläre Studioalben und eine EP veröffentlicht, daneben eine Live-DVD, sowie eine Wiederveröffentlichung der Demos."
+    val input2 = raw"Der Kragenbär, Asiatische Schwarzbär, Mondbär oder Tibetbär (Ursus thibetanus) ist eine Raubtierart aus der Familie der Bären (Ursidae). In seiner Heimat wird er meistens als black bear bezeichnet oder als Baribal. Im Vergleich zum eher gefürchteten Grizzlybär gilt der Schwarzbär als weniger gefährlich."
+
+    //find plagiarisms using default hyper parameters
+    val matches = finder.findPlagiarisms(input + input2, new HyperParameters())
+    //TODO THROWS EXCEPTION
+    val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 3)
+
+    println(wikiExcerpt.size)
+    println(wikiExcerpt)
+    println()
+
+
+    wikiExcerpt.foreach(println(_))
+    assert(true)
+  }
+
+  @Test def testExcerpt2(): Unit = {
+    val input = raw"Und der wwfawf werwe für einen fiktiven Regisseur der Filme verantwortet, bei denen der eigentliche Regisseur seinen Namen nicht Kontaktenfrom. zuletzt', weil Arthur  Hiller  der eigentliche  regisseur "
+    val matches = finder.findPlagiarisms(input, new HyperParameters())
+    //TODO THROWS EXCEPTION
+    val wikiExcerpt = excerptBuilder.buildWikiExcerpts(matches, 3)
 
     println(wikiExcerpt.size)
     println(wikiExcerpt)

--- a/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/Text.scala
+++ b/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/Text.scala
@@ -1,6 +1,0 @@
-package de.htwberlin.f4.wikiplag.rest
-
-case class Text(text:String) {
-
-}
-

--- a/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/models/RestApiPostResponseModel.scala
+++ b/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/models/RestApiPostResponseModel.scala
@@ -1,6 +1,7 @@
 package de.htwberlin.f4.wikiplag.rest.models
 
 import de.htwberlin.f4.wikiplag.plagiarism.models.{WikiExcerpt, WikiPlagiarism}
+import de.htwberlin.f4.wikiplag.utils.Functions
 
 /** transform to mock.json format */
 @SerialVersionUID(1)
@@ -18,9 +19,9 @@ case class RestApiPostResponseModel(var plags: List[WikiPlagiarism],var tagged_i
       //concatenate them
       var plagIndices = (startEndPositionsLists._1 ::: startEndPositionsLists._2).sorted
 
-      var rawTextSplit = SplitByMultipleIndices(plagIndices, rawText)
+      var rawTextSplit = Functions.SplitByMultipleIndices(plagIndices, rawText)
 
-      var span =""" <span class="input_plag" id="%d" > %s <span>""""
+      var span ="""<span class="input_plag" id="%d" >%s</span>""""
 
       tagged_input_text= rawTextSplit.zipWithIndex.map(x => {
         //odd ones are plagiarisms
@@ -33,5 +34,4 @@ case class RestApiPostResponseModel(var plags: List[WikiPlagiarism],var tagged_i
     }
   }
 
-  private def SplitByMultipleIndices(indices: List[Int], s: String) = (indices zip indices.tail) map { case (a, b) => s.substring(a, b) }
-}
+  }

--- a/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/models/Text.scala
+++ b/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/models/Text.scala
@@ -1,0 +1,6 @@
+package de.htwberlin.f4.wikiplag.rest.models
+
+case class Text(text:String) {
+
+}
+

--- a/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/servlets/WikiplagServlet.scala
+++ b/restApi/src/main/scala/de/htwberlin/f4/wikiplag/rest/servlets/WikiplagServlet.scala
@@ -2,8 +2,7 @@ package de.htwberlin.f4.wikiplag.rest.servlets
 
 import de.htwberlin.f4.wikiplag.plagiarism.models.HyperParameters
 import de.htwberlin.f4.wikiplag.plagiarism.{PlagiarismFinder, WikiExcerptBuilder}
-import de.htwberlin.f4.wikiplag.rest.Text
-import de.htwberlin.f4.wikiplag.rest.models.RestApiPostResponseModel
+import de.htwberlin.f4.wikiplag.rest.models.{RestApiPostResponseModel, Text}
 import de.htwberlin.f4.wikiplag.utils.CassandraParameters
 import de.htwberlin.f4.wikiplag.utils.database.CassandraClient
 import org.apache.spark.SparkContext
@@ -16,6 +15,7 @@ class WikiplagServlet extends ScalatraServlet with JacksonJsonSupport {
   protected implicit val jsonFormats: Formats = DefaultFormats
 
   private val separator: String = System.getProperty("file.separator")
+  private val N_CHARS_BEFORE_AND_AFTER=20
 
   private var cassaandraClient: CassandraClient = _
 
@@ -74,9 +74,9 @@ class WikiplagServlet extends ScalatraServlet with JacksonJsonSupport {
       val jValue = parse(jsonString)
       val textObject = jValue.extract[Text]
       val plagiarism = new PlagiarismFinder(cassaandraClient).findPlagiarisms(textObject.text, new HyperParameters())
-      val plagiarismExcrepts = new WikiExcerptBuilder(cassaandraClient).buildWikiExcerpts(plagiarism, 3)
+      val plagiarismExcrepts = new WikiExcerptBuilder(cassaandraClient).buildWikiExcerpts(plagiarism,N_CHARS_BEFORE_AND_AFTER )
 
-      val result  = new RestApiPostResponseModel(plagiarismExcrepts)
+      val result  = RestApiPostResponseModel(plagiarismExcrepts)
       result.InitTaggedInputTextFromRawText(textObject.text)
 
       // for testing webapp

--- a/restApi/src/test/scala/de/htwberlin/f4/wikiplag/rest/WikiplagServletTests.scala
+++ b/restApi/src/test/scala/de/htwberlin/f4/wikiplag/rest/WikiplagServletTests.scala
@@ -6,11 +6,4 @@ import org.scalatest.FunSuiteLike
 
 class WikiplagServletTests extends ScalatraSuite with FunSuiteLike {
 
-  addServlet(classOf[WikiplagServlet], "/*")
-
-  test("GET / on WikiplagServlet should return status 200"){
-    get("/"){
-      status should equal (200)
-    }
-  }
 }

--- a/utils/src/main/scala/de/htwberlin/f4/wikiplag/utils/Functions.scala
+++ b/utils/src/main/scala/de/htwberlin/f4/wikiplag/utils/Functions.scala
@@ -1,0 +1,21 @@
+package de.htwberlin.f4.wikiplag.utils
+
+import scala.collection.mutable
+
+/** Various utility functions
+  */
+object Functions {
+
+  def SplitByMultipleIndices(indices: List[Int], s: String) = (indices zip indices.tail) map { case (a, b) => s.substring(a, b) }
+
+  /*Returns the indices of all occurrences in s of the given keyword as an ordered list.*/
+  def allIndicesOf(s: String, keyword: String): List[Int] = {
+    var listBuffer = new mutable.ListBuffer[Int]
+    var index = s.indexOf(keyword)
+    while (index != -1) {
+      listBuffer.append(index)
+      index = s.indexOf(keyword, index + 1)
+    }
+    listBuffer.toList
+  }
+}


### PR DESCRIPTION
- implement new algorithm which iterates over all query tokens rather than start and end and finds the best matching excerpt of the original Wikipeida document